### PR TITLE
update properties on trackEvent and revenue fallback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,9 +52,11 @@ Optimizely.prototype.initialize = function() {
 };
 
 /**
- * Track.
+ * Track. trackEvent can only send one property, revenue
+ * We fall back to total if it's on the call and revenue is not
  *
  * https://www.optimizely.com/docs/api#track-event
+ * http://developers.optimizely.com/javascript/reference/#api-function-calls
  *
  * @api public
  * @param {Track} track
@@ -62,8 +64,10 @@ Optimizely.prototype.initialize = function() {
 
 Optimizely.prototype.track = function(track) {
   var props = track.properties();
-  if (props.revenue) props.revenue *= 100;
-  push('trackEvent', track.event(), props);
+  var payload = {};
+  var revenue = props.revenue || props.total || props.value;
+  if (revenue) payload.revenue = revenue *= 100;
+  push('trackEvent', track.event(), payload);
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,15 +146,27 @@ describe('Optimizely', function() {
         analytics.called(window.optimizely.push, ['trackEvent', 'event', {}]);
       });
 
-      it('should send an event and properties', function() {
+      it('shouldn\'t send properties it can\'t process', function() {
         analytics.track('event', { property: true });
-        analytics.called(window.optimizely.push, ['trackEvent', 'event', {
-          property: true
-        }]);
+        analytics.called(window.optimizely.push, ['trackEvent', 'event', {}]);
       });
 
       it('should change revenue to cents', function() {
         analytics.track('event', { revenue: 9.99 });
+        analytics.called(window.optimizely.push, ['trackEvent', 'event', {
+          revenue: 999
+        }]);
+      });
+
+      it('should fallback to total if revenue isn\'t on the call', function() {
+        analytics.track('event', { total: 9.99 });
+        analytics.called(window.optimizely.push, ['trackEvent', 'event', {
+          revenue: 999
+        }]);
+      });
+
+      it('should fallback to value if revenue and total aren\'t on the call', function() {
+        analytics.track('event', { value: 9.99 });
         analytics.called(window.optimizely.push, ['trackEvent', 'event', {
           revenue: 999
         }]);
@@ -168,27 +180,12 @@ describe('Optimizely', function() {
 
       it('should send an event for a named page', function() {
         analytics.page('Home');
-        analytics.called(window.optimizely.push, ['trackEvent', 'Viewed Home Page', {
-          name: 'Home',
-          path: window.location.pathname,
-          referrer: document.referrer,
-          title: document.title,
-          search: window.location.search,
-          url: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + window.location.search
-        }]);
+        analytics.called(window.optimizely.push, ['trackEvent', 'Viewed Home Page', {}]);
       });
 
       it('should send an event for a named and categorized page', function() {
         analytics.page('Blog', 'New Integration');
-        analytics.called(window.optimizely.push, ['trackEvent', 'Viewed Blog New Integration Page', {
-          category: 'Blog',
-          name: 'New Integration',
-          path: window.location.pathname,
-          referrer: document.referrer,
-          title: document.title,
-          search: window.location.search,
-          url: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + window.location.search
-        }]);
+        analytics.called(window.optimizely.push, ['trackEvent', 'Viewed Blog New Integration Page', {}]);
       });
     });
   });


### PR DESCRIPTION
We were trying to send all properties to Optimizely but they can only accept one property, `revenue`. I've updated our integration and the tests to reflect this and I've also added a fallback to pass `total` as `revenue` if the latter isn't included in the call's properties.

Some customers want to be able to track the variable monetary values they get with Optimizely test variations but they don't want to use the word revenue since the value they want to pass through isn't equivalent to revenue and they don't want to conflate the two in their raw data to see that in Optimizely.
