### PR TITLE
adding nonInteraction for roots

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,8 @@ var Optimizely = module.exports = integration('Optimizely')
   .option('listen', false)
   .option('trackCategorizedPages', true)
   .option('trackNamedPages', true)
-  .option('variations', true);
+  .option('variations', true)
+  .option('nonInteraction', false);
 
 /**
  * The name and version for this integration.
@@ -119,6 +120,8 @@ Optimizely.prototype.roots = function() {
   var self = this;
 
   each(activeExperiments, function(props) {
+    // make sure the event is labelled as nonInteraction for GA
+    if (self.options.nonInteraction) props.nonInteraction = 1;
     self.analytics.track(
       'Experiment Viewed',
       props,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ var Optimizely = require('../lib/');
 describe('Optimizely', function() {
   var analytics;
   var optimizely;
-  var options = { listen: false };
+  var options = { listen: false, nonInteraction: false };
 
   beforeEach(function() {
     analytics = new Analytics();
@@ -118,6 +118,21 @@ describe('Optimizely', function() {
     it('should send active experiments', function(done) {
       tick(function() {
         analytics.called(analytics.track, 'Experiment Viewed', {
+          experimentId: 0,
+          experimentName: 'Test',
+          variationId: 123,
+          variationName: 'Variation1' },
+          { context: { integration: { name: 'optimizely', version: '1.0.0' } }
+        });
+        done();
+      });
+    });
+
+    it('should send active experiments with nonInteraction when flagged', function(done) {
+      optimizely.options.nonInteraction = true;
+      tick(function() {
+        analytics.called(analytics.track, 'Experiment Viewed', {
+          nonInteraction: 1,
           experimentId: 0,
           experimentName: 'Test',
           variationId: 123,


### PR DESCRIPTION
The Optimizely Roots event was effecting customer's bounce rates in GA since they weren't being specified as nonInteraction.

I added a nonInteraction flag so we don't send this for all customers, and only for those who opt in.
