### PR TITLE
adding support for multivariate experiments closes #3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,6 +119,7 @@ Optimizely.prototype.roots = function() {
     variationNamesMap: data.state.variationNamesMap,
     variationIdsMap: data.state.variationIdsMap,
     activeExperimentIds: data.state.activeExperiments,
+    sections: data.sections,
     allExperiments: allExperiments
   });
   var self = this;
@@ -169,8 +170,9 @@ Optimizely.prototype.replay = function() {
  */
 
 function getExperiments(options) {
-  return foldl(function(results, experimentId) {
+  return foldl(function(results, experimentId, index) {
     var experiment = options.allExperiments[experimentId];
+    var multiVariate = options.sections[experimentId];
     if (experiment) {
       results.push({
         variationName: options.variationNamesMap[experimentId],
@@ -178,6 +180,10 @@ function getExperiments(options) {
         experimentId: experimentId,
         experimentName: experiment.name
       });
+      if (multiVariate) {
+        results[index].sectionName = multiVariate.name;
+        results[index].variationId = multiVariate.variation_ids.join();
+      }
     }
     return results;
   }, [], options.activeExperimentIds);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,11 +18,12 @@ describe('Optimizely', function() {
     analytics.add(optimizely);
 
     window.optimizely.data = {
-      experiments: { 0: { name: 'Test' } },
+      experiments: { 0: { name: 'Test' }, 1: { name: 'MultiVariate Test' } },
+      sections: { 1: { name: 'Section 1', variation_ids: [123, 456, 789] } },
       state: {
         activeExperiments: [0],
-        variationNamesMap: { 0: 'Variation1' },
-        variationIdsMap: { 0: [123] }
+        variationNamesMap: { 0: 'Variation1', 1: 'Variation2' },
+        variationIdsMap: { 0: [123], 1: [123, 456, 789] }
       }
     };
   });
@@ -99,7 +100,8 @@ describe('Optimizely', function() {
       analytics.page();
       tick(function() {
         analytics.called(analytics.identify, {
-          'Experiment: Test': 'Variation1'
+          'Experiment: Test': 'Variation1',
+          'Experiment: MultiVariate Test': 'Variation2'
         });
         done();
       });
@@ -122,6 +124,35 @@ describe('Optimizely', function() {
           experimentName: 'Test',
           variationId: 123,
           variationName: 'Variation1' },
+          { context: { integration: { name: 'optimizely', version: '1.0.0' } }
+        });
+        done();
+      });
+    });
+
+    it('should send active multiVariate experiments', function(done) {
+      window.optimizely.data.state.activeExperiments = [1];
+      tick(function() {
+        analytics.called(analytics.track, 'Experiment Viewed', {
+          sectionName: 'Section 1',
+          experimentId: 1,
+          experimentName: 'MultiVariate Test',
+          variationId: '123,456,789',
+          variationName: 'Variation2' },
+          { context: { integration: { name: 'optimizely', version: '1.0.0' } }
+        });
+        done();
+      });
+    });
+
+    it('shouldn\'t send inactive multiVariate experiments', function(done) {
+      tick(function() {
+        analytics.didNotCall(analytics.track, 'Experiment Viewed', {
+          sectionName: 'Section 1',
+          experimentId: 1,
+          experimentName: 'MultiVariate Test',
+          variationId: '123,456,789',
+          variationName: 'Variation2' },
           { context: { integration: { name: 'optimizely', version: '1.0.0' } }
         });
         done();


### PR DESCRIPTION
Closes https://segment.phacility.com/T416
Adding support for Optimizely's multivariate experiments, allowing us to record multiple variations on a single Page.

There is a sections object on the window.optimizely.data object that contains information about multivariate experiments.

 If there's an active Experiment with an experimentId in the sections object, we add a sectionsName property to the roots call as well as replacing the variationId, which is incorrect in the experiments object for multiVariate Experiments (it only shows one of the multiple variation Ids), with a comma delimited string of all variations in this multivariate Experiment.

http://developers.optimizely.com/javascript/reference/index.html
