### PR TITLE
Fix revenue mapping — don't map value to revenue 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,9 +64,8 @@ Optimizely.prototype.initialize = function() {
  */
 
 Optimizely.prototype.track = function(track) {
-  var props = track.properties();
   var payload = {};
-  var revenue = props.revenue || props.total || props.value;
+  var revenue = track.revenue();
   if (revenue) payload.revenue = revenue *= 100;
   push('trackEvent', track.event(), payload);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,20 +203,6 @@ describe('Optimizely', function() {
           revenue: 999
         }]);
       });
-
-      it('should fallback to total if revenue isn\'t on the call', function() {
-        analytics.track('event', { total: 9.99 });
-        analytics.called(window.optimizely.push, ['trackEvent', 'event', {
-          revenue: 999
-        }]);
-      });
-
-      it('should not proxy value to revenue', function() {
-        analytics.track('event', { value: 13 });
-        analytics.called(window.optimizely.push, ['trackEvent', 'event', {
-          value: 13
-        }]);
-      });
     });
 
     describe('#page', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -211,10 +211,10 @@ describe('Optimizely', function() {
         }]);
       });
 
-      it('should fallback to value if revenue and total aren\'t on the call', function() {
-        analytics.track('event', { value: 9.99 });
+      it('should not proxy value to revenue', function() {
+        analytics.track('event', { value: 13 });
         analytics.called(window.optimizely.push, ['trackEvent', 'event', {
-          revenue: 999
+          value: 13
         }]);
       });
     });


### PR DESCRIPTION
Closes #9 — see discussion there for background.

Per our spec:
- `value` ≠ `revenue`
- `total` is only an acceptable substitute for `revenue` on `Completed Order`
