### PR TITLE
DO NOT MERGE - Send revenue as integer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ Optimizely.prototype.track = function(track) {
     tags: track.properties()
   };
   var revenue = track.revenue();
-  if (revenue) payload.tags.revenue *= 100;
+  if (revenue) Math.round(payload.tags.revenue *= 100);
 
   push(payload);
 


### PR DESCRIPTION
Use Math.round() to enforce that Optimizely receives an integer for revenue