### PR TITLE
Adds options to send revenue only on Order Completed events.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,11 +90,16 @@ Optimizely.prototype.track = function(track) {
   var opts = this.options;
   var eventProperties = track.properties();
 
-  if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted && track.event() === 'Order Completed') {
-    eventProperties.revenue = Math.round(eventProperties.revenue * 100);
-  } else if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted && track.event() !== 'Order Completed') {
-    delete eventProperties.revenue;
-  } else if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted === false) {
+  // Optimizely expects revenue only passed through Order Completed events
+  if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted) {
+    if (track.event() === 'Order Completed') {
+      eventProperties.revenue = Math.round(eventProperties.revenue * 100);
+    } else if (track.event() !== 'Order Completed') {
+      delete eventProperties.revenue;
+    }
+    // This is legacy Segment-Optimizely behavior, 
+    // which passes revenue whenever it is present
+  } else if (opts.sendRevenueOnlyForOrderCompleted === false && eventProperties.revenue) {
     eventProperties.revenue = Math.round(eventProperties.revenue * 100);
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,7 @@ Optimizely.prototype.initialize = function() {
  */
 
 Optimizely.prototype.track = function(track) {
+  var opts = this.options;
   // Use the new-style API (which is compatible with Classic and X)
   var payload = {
     type: 'event',
@@ -93,7 +94,11 @@ Optimizely.prototype.track = function(track) {
     tags: track.properties()
   };
 
-  if (payload.tags.revenue) {
+  if (payload.tags.revenue && opts.sendRevenueOnlyForOrderCompleted) {
+    if (track.event() === 'Order Completed') {
+      payload.tags.revenue = Math.round(payload.tags.revenue * 100);
+    }
+  } else if (payload.tags.revenue) {
     payload.tags.revenue = Math.round(payload.tags.revenue * 100);
   }
 
@@ -518,4 +523,3 @@ Optimizely.initOptimizelyIntegration = function(handlers) {
   initClassicOptimizelyIntegration(handlers.referrerOverride, handlers.sendExperimentData);
   initNewOptimizelyIntegration(handlers.referrerOverride, handlers.sendCampaignData);
 };
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,14 +93,14 @@ Optimizely.prototype.track = function(track) {
   var payload = {
     type: 'event',
     eventName: track.event(),
-    tags: track.properties()
+    tags: eventProperties
   };
 
-  if (payload.tags.revenue && opts.sendRevenueOnlyForOrderCompleted) {
+  if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted) {
     if (track.event() === 'Order Completed') {
       payload.tags.revenue = Math.round(payload.tags.revenue * 100);
     }
-  } else if (payload.tags.revenue) {
+  } else if (eventProperties.revenue) {
     payload.tags.revenue = Math.round(payload.tags.revenue * 100);
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ var Optimizely = module.exports = integration('Optimizely')
   .option('trackNamedPages', true)
   .option('variations', false) // send data via `.identify()`
   .option('listen', true) // send data via `.track()`
-  .option('nonInteraction', false);
+  .option('nonInteraction', false)
+  .option('sendRevenueOnlyForOrderCompleted', false);
 
 /**
  * The name and version for this integration.

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ Optimizely.prototype.initialize = function() {
 
 Optimizely.prototype.track = function(track) {
   var opts = this.options;
+  var eventProperties = track.properties();
   // Use the new-style API (which is compatible with Classic and X)
   var payload = {
     type: 'event',
@@ -107,7 +108,6 @@ Optimizely.prototype.track = function(track) {
 
   var optimizelyClientInstance = window.optimizelyClientInstance;
   if (optimizelyClientInstance && optimizelyClientInstance.track) {
-    var eventProperties = track.properties();
     var optimizelyOptions = track.options('Optimizely');
     var userId = optimizelyOptions.userId || track.userId() || this.analytics.user().id();
     var attributes = optimizelyOptions.attributes || track.traits() || this.analytics.user().traits();

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ var Optimizely = module.exports = integration('Optimizely')
   .option('variations', false) // send data via `.identify()`
   .option('listen', true) // send data via `.track()`
   .option('nonInteraction', false)
-  .option('sendRevenueOnlyForOrderCompleted', false);
+  .option('sendRevenueOnlyForOrderCompleted', true);
 
 /**
  * The name and version for this integration.
@@ -89,20 +89,21 @@ Optimizely.prototype.initialize = function() {
 Optimizely.prototype.track = function(track) {
   var opts = this.options;
   var eventProperties = track.properties();
+
+  if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted && track.event() === 'Order Completed') {
+    eventProperties.revenue = Math.round(eventProperties.revenue * 100);
+  } else if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted && track.event() !== 'Order Completed') {
+    delete eventProperties.revenue;
+  } else if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted === false) {
+    eventProperties.revenue = Math.round(eventProperties.revenue * 100);
+  }
+
   // Use the new-style API (which is compatible with Classic and X)
   var payload = {
     type: 'event',
     eventName: track.event(),
     tags: eventProperties
   };
-
-  if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted) {
-    if (track.event() === 'Order Completed') {
-      payload.tags.revenue = Math.round(payload.tags.revenue * 100);
-    }
-  } else if (eventProperties.revenue) {
-    payload.tags.revenue = Math.round(payload.tags.revenue * 100);
-  }
 
   push(payload);
 
@@ -112,7 +113,7 @@ Optimizely.prototype.track = function(track) {
     var userId = optimizelyOptions.userId || track.userId() || this.analytics.user().id();
     var attributes = optimizelyOptions.attributes || track.traits() || this.analytics.user().traits();
     if (userId) {
-      optimizelyClientInstance.track(track.event(), userId, attributes, eventProperties);
+      optimizelyClientInstance.track(track.event(), userId, attributes, payload.tags);
     }
   }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -504,7 +504,19 @@ describe('Optimizely', function() {
         analytics.stub(window.optimizely, 'push');
       });
 
-      it('should send revenue only on Order Completed if onlySendRevenueOnOrderCompleted is enabled', function() {
+      it('should not include revenue on a non Order Completed event if `onlySendRevenueOnOrderCompleted` is enabled', function() {
+        analytics.initialize();
+        analytics.track('Order Updated', {
+          revenue: 25
+        });
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'Order Updated',
+          tags: {}
+        });
+      });
+
+      it('should send revenue only on Order Completed if `onlySendRevenueOnOrderCompleted` is enabled', function() {
         analytics.initialize();
         analytics.track('Order Completed', {
           revenue: 9.99
@@ -711,6 +723,18 @@ describe('Optimizely', function() {
     describe('#options.sendRevenueOnlyForOrderCompleted', function() {
       beforeEach(function() {
         analytics.stub(window.optimizely, 'push');
+      });
+
+      it('should not include revenue on a non Order Completed event if `onlySendRevenueOnOrderCompleted` is enabled', function() {
+        analytics.initialize();
+        analytics.track('Order Updated', {
+          revenue: 25
+        });
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'Order Updated',
+          tags: {}
+        });
       });
 
       it('should send revenue only on Order Completed if `onlySendRevenueOnOrderCompleted` is enabled', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -505,7 +505,6 @@ describe('Optimizely', function() {
       });
 
       it('should send revenue only on Order Completed if onlySendRevenueOnOrderCompleted is enabled', function() {
-        optimizely.options.sendRevenueOnlyForOrderCompleted = true;
         analytics.initialize();
         analytics.track('Order Completed', {
           revenue: 9.99
@@ -519,7 +518,8 @@ describe('Optimizely', function() {
         });
       });
 
-      it('should default to sending revenue on events with properties.revenue', function() {
+      it('should send revenue on all events with properties.revenue if `onlySendRevenueOnOrderCompleted` is disabled', function() {
+        optimizely.options.sendRevenueOnlyForOrderCompleted = false;
         analytics.initialize();
         analytics.track('Checkout Started', {
           revenue: 9.99
@@ -713,7 +713,7 @@ describe('Optimizely', function() {
         analytics.stub(window.optimizely, 'push');
       });
 
-      it('should send revenue only on Order Completed if onlySendRevenueOnOrderCompleted is enabled', function() {
+      it('should send revenue only on Order Completed if `onlySendRevenueOnOrderCompleted` is enabled', function() {
         optimizely.options.sendRevenueOnlyForOrderCompleted = true;
         analytics.initialize();
         analytics.track('Order Completed', {
@@ -728,7 +728,8 @@ describe('Optimizely', function() {
         });
       });
 
-      it('should default to sending revenue on events with properties.revenue', function() {
+      it('should send revenue on all events with properties.revenue if `onlySendRevenueOnOrderCompleted` is disabled', function() {
+        optimizely.options.sendRevenueOnlyForOrderCompleted = false;
         analytics.initialize();
         analytics.track('Checkout Started', {
           revenue: 9.99
@@ -895,19 +896,19 @@ describe('Optimizely', function() {
       });
 
       it('should change revenue to cents and include in tags', function() {
-        analytics.track('event', { revenue: 9.99 });
+        analytics.track('Order Completed', { revenue: 9.99 });
         analytics.called(window.optimizely.push, {
           type: 'event',
-          eventName: 'event',
+          eventName: 'Order Completed',
           tags: { revenue: 999 }
         });
       });
 
       it('should round the revenue value to an integer value if passed in as a floating point number', function() {
-        analytics.track('event', { revenue: 534.3099999999999 });
+        analytics.track('Order Completed', { revenue: 534.3099999999999 });
         analytics.called(window.optimizely.push, {
           type: 'event',
-          eventName: 'event',
+          eventName: 'Order Completed',
           tags: { revenue: 53431 }
         });
       });
@@ -931,6 +932,22 @@ describe('Optimizely', function() {
         it('should send an event through the Optimizely X Fullstack JS SDK using the user provider user id', function() {
           analytics.track('event', { purchasePrice: 9.99, property: 'foo' }, { Optimizely: { userId: 'user1', attributes: { country: 'usa' } } });
           analytics.called(window.optimizelyClientInstance.track, 'event', 'user1', { country: 'usa' }, { property: 'foo', purchasePrice: 9.99 });
+        });
+
+        it('should send revenue on `Order Completed` through the Optimizely X Fullstack JS SDK and `properites.revenue` is passed', function() {
+          analytics.track('Order Completed', { purchasePrice: 9.99, property: 'foo', revenue: 1.99 }, { Optimizely: { userId: 'user1', attributes: { country: 'usa' } } });
+          analytics.called(window.optimizelyClientInstance.track, 'Order Completed', 'user1', { country: 'usa' }, { property: 'foo', purchasePrice: 9.99, revenue: 199 });
+        });
+
+        it('should not default to sending revenue through the Optimizely X Fullstack JS SDK on non `Order Completed` events and `properites.revenue` is passed', function() {
+          analytics.track('event', { purchasePrice: 9.99, property: 'foo', revenue: 1.99 }, { Optimizely: { userId: 'user1', attributes: { country: 'usa' } } });
+          analytics.called(window.optimizelyClientInstance.track, 'event', 'user1', { country: 'usa' }, { property: 'foo', purchasePrice: 9.99 });
+        });
+
+        it('should send revenue through the Optimizely X Fullstack JS SDK on all events if `sendRevenueOnlyForOrderCompleted` is disabled and `properites.revenue` is passed', function() {
+          optimizely.options.sendRevenueOnlyForOrderCompleted = false;
+          analytics.track('event', { purchasePrice: 9.99, property: 'foo', revenue: 1.99 }, { Optimizely: { userId: 'user1', attributes: { country: 'usa' } } });
+          analytics.called(window.optimizelyClientInstance.track, 'event', 'user1', { country: 'usa' }, { property: 'foo', purchasePrice: 9.99, revenue: 199 });
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -499,6 +499,42 @@ describe('Optimizely', function() {
       });
     });
 
+    describe('#options.sendRevenueOnlyForOrderCompleted', function() {
+      beforeEach(function() {
+        analytics.stub(window.optimizely, 'push');
+      });
+
+      it('should send revenue only on Order Completed if onlySendRevenueOnOrderCompleted is enabled', function() {
+        optimizely.options.sendRevenueOnlyForOrderCompleted = true;
+        analytics.initialize();
+        analytics.track('Order Completed', {
+          revenue: 9.99
+        });
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'Order Completed',
+          tags: {
+            revenue: 999
+          }
+        });
+      });
+
+      it('should default to sending revenue on events with properties.revenue', function() {
+        analytics.initialize();
+        analytics.track('Checkout Started', {
+          revenue: 9.99
+        });
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'Checkout Started',
+          tags: {
+            revenue: 999
+          }
+        });
+      });
+    });
+
+
     describe('#options.listen', function() {
       beforeEach(function() {
         optimizely.options.listen = true;
@@ -669,6 +705,41 @@ describe('Optimizely', function() {
         analytics.deepEqual(analytics.identify.args[1], [{
           'Experiment: Worlds Group Stage': 'Variation #1'
         }]);
+      });
+    });
+
+    describe('#options.sendRevenueOnlyForOrderCompleted', function() {
+      beforeEach(function() {
+        analytics.stub(window.optimizely, 'push');
+      });
+
+      it('should send revenue only on Order Completed if onlySendRevenueOnOrderCompleted is enabled', function() {
+        optimizely.options.sendRevenueOnlyForOrderCompleted = true;
+        analytics.initialize();
+        analytics.track('Order Completed', {
+          revenue: 9.99
+        });
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'Order Completed',
+          tags: {
+            revenue: 999
+          }
+        });
+      });
+
+      it('should default to sending revenue on events with properties.revenue', function() {
+        analytics.initialize();
+        analytics.track('Checkout Started', {
+          revenue: 9.99
+        });
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'Checkout Started',
+          tags: {
+            revenue: 999
+          }
+        });
       });
     });
 


### PR DESCRIPTION
Current behavior: Optimizely calculates revenue on all calls containing `properties.revenue`. Our ecommerce v2 spec advises sending in `revenue` on  `Checkout Started`, `Order Updated`, `Order Cancelled` and `Order Completed` events. 

Unlike most other metrics in Optimizely, the revenue metric is cumulative and is not de-duplicated based on the visitor’s unique user ID or another identifier like order ID. As such, revenue will be counted toward the variation total each time Optimizely receives a revenue amount, so the total revenue ends up be inflated based on how users will send revenue as advised via our spec.

The fix will add an option to only send `properties.revenue` on `Order Completed` events. This will be defaulted to false as this will cause a breaking change to users expecting `revenue` to be calculated on all events. 

This affects both [Optimizely Classic](https://help.optimizely.com/Measure_success%3A_Track_visitor_behaviors/Revenue_tracking_goals_in_Optimizely_Classic) and [Optimizely X](https://help.optimizely.com/Measure_success%3A_Track_visitor_behaviors/Set_up_revenue_tracking_in_Optimizely_X_Web)