### PR TITLE
Support "Completed Order"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,9 +92,9 @@ Optimizely.prototype.track = function(track) {
 
   // Optimizely expects revenue only passed through Order Completed events
   if (eventProperties.revenue && opts.sendRevenueOnlyForOrderCompleted) {
-    if (track.event() === 'Order Completed') {
+    if (track.event() === 'Order Completed' || track.event() === 'Completed Order') {
       eventProperties.revenue = Math.round(eventProperties.revenue * 100);
-    } else if (track.event() !== 'Order Completed') {
+    } else {
       delete eventProperties.revenue;
     }
     // This is legacy Segment-Optimizely behavior, 


### PR DESCRIPTION
Support the legacy "Completed Order" event name. Some customers still use that, and this change will allow them to use Optimizely as intended without changing their code base.