### PR TITLE
Add 'isInCampaignHoldback' property to track calls

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+3.3.2 / 2017-11-15
+==================
+
+  * Add 'isInCampaignHoldback' property to track calls
+
 3.3.1 / 2017-04-17
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -273,6 +273,7 @@ Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
  * @param {Object} campaignState.variation: the variation the visitor is seeing
  * @param {String} campaignState.variation.id: the id of the variation
  * @param {String} campaignState.variation.name: the name of the variation
+ * @param {String} campaignState.isInCampaignHoldback: whether the visitor is in the Campaign holdback 
  */
 
 Optimizely.prototype.sendNewDataToSegment = function(campaignState) {
@@ -300,7 +301,8 @@ Optimizely.prototype.sendNewDataToSegment = function(campaignState) {
       variationName: variation.name,
       variationId: variation.id,
       audienceId: audienceIds, // eg. '7527562222,7527111138'
-      audienceName: audienceNames // eg. 'Peaky Blinders, Trust Tree'
+      audienceName: audienceNames, // eg. 'Peaky Blinders, Trust Tree'
+      isInCampaignHoldback: campaignState.isInCampaignHoldback
     };
 
     // If this was a redirect experiment and the effective referrer is different from document.referrer,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-optimizely",
   "description": "The Optimizely analytics.js integration.",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,9 +69,9 @@ var mockOptimizelyXDataObject = function() {
         id: '7551111120',
         name: 'Variation Corruption #1884'
       },
+      isInCampaignHoldback: false,      
       // these are returned by real Optimizely API but will not be send to integrations
       isActive: false,
-      isInCampaignHoldback: false,
       reason: undefined,
       visitorRedirected: true
     },
@@ -92,9 +92,9 @@ var mockOptimizelyXDataObject = function() {
         id: '7557950020',
         name: 'Variation #1'
       },
+      isInCampaignHoldback: true,      
       // these are returned by real Optimizely API but will not be send to integrations
       isActive: true,
-      isInCampaignHoldback: false,
       reason: undefined,
       visitorRedirected: false
     },
@@ -119,9 +119,9 @@ var mockOptimizelyXDataObject = function() {
         id: '7333333333',
         name: 'Variation DBC'
       },
+      isInCampaignHoldback: false,      
       // these are returned by real Optimizely API but will not be send to integrations
       isActive: true,
-      isInCampaignHoldback: false,
       reason: undefined,
       visitorRedirected: false
     }
@@ -335,7 +335,7 @@ describe('Optimizely', function() {
                   name: 'Variation #1'
                 },
                 isActive: true,
-                isInCampaignHoldback: false,
+                isInCampaignHoldback: true,
                 reason: undefined,
                 visitorRedirected: false
               }
@@ -428,7 +428,7 @@ describe('Optimizely', function() {
                   name: 'Variation #1'
                 },
                 isActive: true,
-                isInCampaignHoldback: false,
+                isInCampaignHoldback: true,
                 reason: undefined,
                 visitorRedirected: false
               }
@@ -791,7 +791,8 @@ describe('Optimizely', function() {
               variationId: '7333333333',
               variationName: 'Variation DBC',
               audienceId: '1234567890,8888222438',
-              audienceName: 'Fam Yolo, Penthouse 6'
+              audienceName: 'Fam Yolo, Penthouse 6',
+              isInCampaignHoldback: false
             },
             { integration: optimizelyContext }
           ]);
@@ -814,7 +815,8 @@ describe('Optimizely', function() {
               variationId: '7557950020',
               variationName: 'Variation #1',
               audienceId: '7527565438',
-              audienceName: 'Trust Tree'
+              audienceName: 'Trust Tree',
+              isInCampaignHoldback: true
             },
             { integration: optimizelyContext }
           ]);
@@ -843,7 +845,8 @@ describe('Optimizely', function() {
               variationName: 'Variation Corruption #1884',
               audienceId: '7100568438',
               audienceName: 'Middle Class',
-              referrer: 'barstools.com'
+              referrer: 'barstools.com',
+              isInCampaignHoldback: false
             },
             context
           ]);
@@ -868,7 +871,8 @@ describe('Optimizely', function() {
               variationName: 'Variation #1',
               audienceId: '7527565438',
               audienceName: 'Trust Tree',
-              nonInteraction: 1
+              nonInteraction: 1,
+              isInCampaignHoldback: true
             },
             { integration: optimizelyContext }
           ]);


### PR DESCRIPTION
https://segment.atlassian.net/browse/PLATFORM-1677

Adds the `isInCampaignHoldback` property that Optimizely has been sending us but we have previously been omitting