### PR TITLE
Optimizely event names rejects colons PLATFORM-2261

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ Optimizely.prototype.track = function(track) {
   // Use the new-style API (which is compatible with Classic and X)
   var payload = {
     type: 'event',
-    eventName: track.event(),
+    eventName: track.event().replace(/:/g, '_'), // can't have colons so replacing with underscores
     tags: eventProperties
   };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -913,6 +913,15 @@ describe('Optimizely', function() {
           tags: {}
         });
       });
+      
+      it('should repace colons with underscore in eventName', function() {
+        analytics.track('event:foo:bar');
+        analytics.called(window.optimizely.push, {
+          type: 'event',
+          eventName: 'event_foo_bar',
+          tags: {}
+        });
+      });
 
       it('should send all additional properties along as tags', function() {
         analytics.track('event', { id: 'c00lHa$h', name: 'jerry' });


### PR DESCRIPTION
The full documentation for our custom events are available here: https://help.optimizely.com/Build_Campaigns_and_Experiments/Custom_events_in_Optimizely_X#Format_to_add_a_custom_event_for_web_experiments

The specific specs for valid characters are described in a “Note” on that page: “When creating a Custom Event, the API Name will automatically populate the “eventName” in the API Call. To ensure that the Custom Event is tracked properly in your results, API names may only contain letters, numbers, hyphens, underscores, spaces and periods, and must be shorter than 64 characters.”


biz context: this is causing issues for customers with track event names that have colons in it as optimizely rejects these

cc @ladanazita @jlee9595 @ccnixon if someone can deploy this week would be much appreciated! very important for a customer we are working w atm 🙏 

JIRA https://segment.atlassian.net/browse/PLATFORM-2261