### PR TITLE
also strip colon in event name for full stack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,9 +104,10 @@ Optimizely.prototype.track = function(track) {
   }
 
   // Use the new-style API (which is compatible with Classic and X)
+  var eventName = track.event().replace(/:/g, '_'), // can't have colons so replacing with underscores
   var payload = {
     type: 'event',
-    eventName: track.event().replace(/:/g, '_'), // can't have colons so replacing with underscores
+    eventName: eventName,
     tags: eventProperties
   };
 
@@ -118,7 +119,7 @@ Optimizely.prototype.track = function(track) {
     var userId = optimizelyOptions.userId || track.userId() || this.analytics.user().id();
     var attributes = optimizelyOptions.attributes || track.traits() || this.analytics.user().traits();
     if (userId) {
-      optimizelyClientInstance.track(track.event(), userId, attributes, payload.tags);
+      optimizelyClientInstance.track(eventName, userId, attributes, payload.tags);
     }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ Optimizely.prototype.track = function(track) {
   }
 
   // Use the new-style API (which is compatible with Classic and X)
-  var eventName = track.event().replace(/:/g, '_'), // can't have colons so replacing with underscores
+  var eventName = track.event().replace(/:/g, '_'); // can't have colons so replacing with underscores
   var payload = {
     type: 'event',
     eventName: eventName,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -966,6 +966,12 @@ describe('Optimizely', function() {
           analytics.called(window.optimizelyClientInstance.track, 'event', 'user1', {}, { purchasePrice: 9.99, property: 'foo' });
         });
 
+        it('should replace colons with underscores for event names', function() {
+          analytics.identify('user1');
+          analytics.track('foo:bar:baz');
+          analytics.called(window.optimizelyClientInstance.track, 'foo_bar_baz', 'user1', {}, {});
+        });
+
         it('should send an event through the Optimizely X Fullstack JS SDK using the user provider user id', function() {
           analytics.track('event', { purchasePrice: 9.99, property: 'foo' }, { Optimizely: { userId: 'user1', attributes: { country: 'usa' } } });
           analytics.called(window.optimizelyClientInstance.track, 'event', 'user1', { country: 'usa' }, { property: 'foo', purchasePrice: 9.99 });


### PR DESCRIPTION
this is required change also for full stack.

#41 was fixing event name including colons for their optimizely x web projects. this is mistakenly omitted so adding this fix now 